### PR TITLE
Modify to use ORIGINAL_URL for HTTP_HOST when proxying request

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -95,7 +95,7 @@ def parse_headers(request)
                                      k.start_with?('HTTP_') && k != "HTTP_ACCEPT_ENCODING" }
                                .map { |k,v| [ k.gsub(/^HTTP_/,"")
                                     .downcase.gsub(/(^|_)\w/) { |word| word.upcase }
-                                    .gsub("_", "-") , v
+                                    .gsub("_", "-") , k == 'HTTP_HOST' ? ORIGIN_URL.gsub(/^https?:\/\//, '').gsub(/\/?$/, '') : v
                                 ] }
     return http_headers
 end


### PR DESCRIPTION
バックエンドサーバにリクエストをプロキシしたときはHTTP_HOSTヘッダもORIGINA_URLに切り替わったほうが便利だと思うのですがいかがでしょうか。

Ref: https://github.com/nyankichi820/stubsever/issues/1
