### PR TITLE
Add documentation for origin_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,6 @@ stubしないリクエストは直接ORIGIN_URLに指定したサーバーへリ
 これらのファイルをcopyして再利用することにより,stubデータに使用できます。
 
 
+#### default server
+stubしないリクエストがプロキシされるデフォルトのURLは
+`config/config.yml` の `origin_url: URL` で指定します。


### PR DESCRIPTION
ソースを見れば簡単に分かるのですが、`origin_url` の設定ファイルについてもドキュメントが有ったほうが分かりやすいと思ったのでREADMEを編集しました。
